### PR TITLE
facebook: Fix exception help text

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -36,7 +36,7 @@ websites:
       sms: Yes
       software: Yes
       exceptions:
-          text: "SMS required for 2FA. 1 account per phone number, 1 phone number per account."
+          text: "SMS required for 2FA setup, but OATH generator/Facebook mobile app can be added afterwards."
       doc: https://www.facebook.com/help/148233965247823
 
     - name: Foursquare


### PR DESCRIPTION
Facebook allows multiple mobile phones per account (and will indeed SMS-text all of them simultaneously upon login). User can switch to TOTP OATH after initial setup using any GAuth app, or via the Facebook mobile app which has an OATH generator built-in.
